### PR TITLE
Enable login, logout from marketing and dashboard

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,6 +87,28 @@ export default {
 
   router: {
     middleware: 'commonHeaderRedirect',
+    extendRoutes(routes) {
+      routes.push({
+        path: '/ppr-marketing/signin/bcsc',
+        component: '~/pages/signin/bcsc.vue',
+      })
+      routes.push({
+        path: '/ppr-marketing/signin/bceid',
+        component: '~/pages/signin/bceid.vue',
+      })
+      routes.push({
+        path: '/ppr-marketing/signin/idir',
+        component: '~/pages/signin/idir.vue',
+      })
+      routes.push({
+        path: '/ppr-marketing/signout',
+        component: '~/pages/signout.vue',
+      })
+      routes.push({
+        path: '/dashboard/signout',
+        component: '~/pages/signout.vue',
+      })
+    },
   },
 
   // Environment variables for all site links defined here.

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -40,7 +40,7 @@ export default {
       context.redirect('/signin')
     }
   },
-  data(context) {
+  data() {
     return {
       productInfo: { ...ProductInfo },
       subscribedProducts: []

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -35,10 +35,12 @@ export default {
   components: {
     UserProduct
   },
-  data(context) {
+  asyncData(context) {
     if (!sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)) {
       context.redirect('/signin')
     }
+  },
+  data(context) {
     return {
       productInfo: { ...ProductInfo },
       subscribedProducts: []


### PR DESCRIPTION
Issue #: /bcgov/entity#9820

Description of changes:
Improve static site login/logout from ppr-marketing and dashboard.

Signed-off-by: Doug Lovett <doug@diamante.ca>