### PR TITLE
10697 Update account retry to 100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bc-registry",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bc-registry",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@mdi/font": "6.5.95",
         "@nuxt/content": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-registry",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -85,9 +85,9 @@ export default Vue.extend ({
   },
   async mounted () {
     // get account id from object in session storage
-    // wait up to 1 sec for current account to be synced (typically by SbcHeader)
+    // wait up to 10 sec for current account to be synced (typically by SbcHeader)
     let accountId: number
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 100; i++) {
       const currentAccount = sessionStorage.getItem(SessionStorageKeys.CurrentAccount)
       const account = JSON.parse(currentAccount)
       accountId = account?.id as number


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10697

*Description of changes:*

Sometimes, waiting 10 times (total: 1 second) isn’t enough time for SbcHeader to update the current account asynchronously. This PR changes this to 100 times (10 sec max). It will return as soon as it gets what it’s looking for. If it times out then the user will not see their product tiles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).