### PR TITLE
sbc-common-component version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "http-status-codes": "^2.1.4",
         "launchdarkly-js-client-sdk": "^2.20.0",
         "nuxt": "^2.15.3",
-        "sbc-common-components": "2.4.46"
+        "sbc-common-components": "2.4.52"
       },
       "devDependencies": {
         "@nuxt/types": "^2.15.3",
@@ -19042,9 +19042,9 @@
       }
     },
     "node_modules/sbc-common-components": {
-      "version": "2.4.46",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.4.46.tgz",
-      "integrity": "sha512-SJs0Ga1X49SOqTvJUXboMY57OBLcW6hjb7VSqHZ7y6bSCQp0xnqzRVMpi63SSRKB5rbxRwrp0QGQApKytuB97Q==",
+      "version": "2.4.52",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.4.52.tgz",
+      "integrity": "sha512-Q7tmhmwjazYnjw4YF02Xe3e539Bkxr8TMzIapiscruqQbNZhXvPi//YOnPsgTcODvSEtCqXGHPRpYPYLrkgjow==",
       "dependencies": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.21.1",
@@ -37766,9 +37766,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "2.4.46",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.4.46.tgz",
-      "integrity": "sha512-SJs0Ga1X49SOqTvJUXboMY57OBLcW6hjb7VSqHZ7y6bSCQp0xnqzRVMpi63SSRKB5rbxRwrp0QGQApKytuB97Q==",
+      "version": "2.4.52",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.4.52.tgz",
+      "integrity": "sha512-Q7tmhmwjazYnjw4YF02Xe3e539Bkxr8TMzIapiscruqQbNZhXvPi//YOnPsgTcODvSEtCqXGHPRpYPYLrkgjow==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bc-registry",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bc-registry",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "@mdi/font": "6.5.95",
         "@nuxt/content": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-registry",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "http-status-codes": "^2.1.4",
     "launchdarkly-js-client-sdk": "^2.20.0",
     "nuxt": "^2.15.3",
-    "sbc-common-components": "2.4.46"
+    "sbc-common-components": "2.4.52"
   },
   "devDependencies": {
     "@nuxt/types": "^2.15.3",


### PR DESCRIPTION
Issue #:
https://github.com/bcgov/entity/issues/12363

sbc-common-component update:
* in version ("version": "2.4.52",) include changes for account switch redirect to main dashboard instead of registries home page.
