### PR TITLE
Fix fallback to default. Readd defaults for cso, esra, rpt.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bc-registry",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bc-registry",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "dependencies": {
         "@mdi/font": "6.5.95",
         "@nuxt/content": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-registry",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "scripts": {
     "dev": "nuxt",

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -89,7 +89,7 @@ export async function updateLdUser (
  * @returns the flag value/variation, or undefined if the flag is not found
  */
 export function getFeatureFlag (name: string): any {
-  return ldClient ? ldClient.variation(name) : defaultFlagSet[name]
+  return ldClient ? ldClient.variation(name, defaultFlagSet[name]) : defaultFlagSet[name]
 }
 
 /**

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -7,13 +7,14 @@ declare const window: any
  * Default flag values when LD is not available.
  * NOTE: To disable dashboard tiles, you require an entry in here.
  * Otherwise the tile will get disabled on the frontpage, but not under the dashboard section.
- * These also don't seem to be working when you use a tool to block LaunchDarkly. This needs to be fixed in the future.
  */
 const defaultFlagSet: LDFlagSet = {
   'bcregistry-ui-bca-enabled': false,
   'bcregistry-ui-bus-search-enabled': true,
   'bcregistry-ui-bus-search-beta-chip': false,
   'bcregistry-ui-bus-search-coming-soon-chip': false,
+  'bcregistry-ui-cso-enabled': true,
+  'bcregistry-ui-esra-enabled': true,
   'bcregistry-ui-mhr-enabled': true,
   'bcregistry-ui-nds-enabled': false,
   'bcregistry-ui-ppr-new-chip': true,

--- a/utils/feature-flags.ts
+++ b/utils/feature-flags.ts
@@ -19,6 +19,7 @@ const defaultFlagSet: LDFlagSet = {
   'bcregistry-ui-nds-enabled': false,
   'bcregistry-ui-ppr-new-chip': true,
   'bcregistry-ui-rpt-new-chip': true,
+  'bcregistry-ui-rpt-enabled': true,
   'bcregistry-ui-wills-new-chip': true,
   'banner-text': ' ',
   'whats-new': ' '


### PR DESCRIPTION
When launch darkly is blocked, the client can still exist - but we need the fallback parameter to be populated.