### PR TITLE
21157 - Add Release Notes to all BC Registries websites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "http-status-codes": "^2.1.4",
         "launchdarkly-js-client-sdk": "^2.20.0",
         "nuxt": "^2.15.8",
-        "sbc-common-components": "3.0.3"
+        "sbc-common-components": "3.0.12"
       },
       "devDependencies": {
         "@nuxt/types": "^2.15.3",
@@ -19054,9 +19054,9 @@
       }
     },
     "node_modules/sbc-common-components": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.3.tgz",
-      "integrity": "sha512-gwHA3G+rWsgrpzfK06QYSO8jw+5aeLlkhSaORu6ZQHyxlGNR/xuvfo0bIJ5dmxHr3Hh3Fm/McnKRea/0dq2VxA==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.12.tgz",
+      "integrity": "sha512-xi+zRXCyhnlKQgqbDoPd64Mrs/peB3+TwBv8H3VoEAVkVVr+z6mxfn+ej4WIlGv8KPQkL30LGBQRuZ0TG/JwxQ==",
       "dependencies": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.21.1",
@@ -37795,9 +37795,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.3.tgz",
-      "integrity": "sha512-gwHA3G+rWsgrpzfK06QYSO8jw+5aeLlkhSaORu6ZQHyxlGNR/xuvfo0bIJ5dmxHr3Hh3Fm/McnKRea/0dq2VxA==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.12.tgz",
+      "integrity": "sha512-xi+zRXCyhnlKQgqbDoPd64Mrs/peB3+TwBv8H3VoEAVkVVr+z6mxfn+ej4WIlGv8KPQkL30LGBQRuZ0TG/JwxQ==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-registry",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "scripts": {
     "dev": "nuxt",
@@ -20,7 +20,7 @@
     "http-status-codes": "^2.1.4",
     "launchdarkly-js-client-sdk": "^2.20.0",
     "nuxt": "^2.15.8",
-    "sbc-common-components": "3.0.3"
+    "sbc-common-components": "3.0.12"
   },
   "devDependencies": {
     "@nuxt/types": "^2.15.3",


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/21157

*Description of changes:* Add Release Notes to all BC Registries websites - For Auth pages