### PR TITLE
27371 - Fixed login link redirection

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,7 +40,8 @@ export default defineNuxtConfig({
   routeRules: {
     '/': { redirect: '/en-CA' },
     '/fr-CA': { prerender: false },
-    '/fr-CA/**': { prerender: false }
+    '/fr-CA/**': { prerender: false },
+    '/login/**': { redirect: '/en-CA/login' }
   },
 
   i18n: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-registry",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/27371

Fixed the issue where the magic link loses it's query parameters after login.

Example:
https://dev.business-registry-dashboard.bcregistry.gov.bc.ca/continueInNow/?nr=NR+9109326&email=karim.jazzar%40gov.bc.ca&phone=1112223333

After login and redirection, goes back to
https://dev.business-registry-dashboard.bcregistry.gov.bc.ca/continueInNow

My change to the configuration adds a route rule that redirects ANY URL starting with /login/ to /en-CA/login. This is crucial because it ensures that when your application receives a URL like /login/?return=https%3A%2F%2F, it properly redirects to the locale-prefixed route. This'll ensure that the query parameters are maintained.